### PR TITLE
Add map multibinding to the sample

### DIFF
--- a/sample/library/src/main/java/com/squareup/anvil/sample/DescriptionComponent.kt
+++ b/sample/library/src/main/java/com/squareup/anvil/sample/DescriptionComponent.kt
@@ -3,10 +3,12 @@ package com.squareup.anvil.sample
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.sample.father.FatherProvider
 import com.squareup.anvil.sample.mother.MotherProvider
+import com.squareup.anvil.sample.pet.Pet
 import com.squareup.scopes.AppScope
 
 @ContributesTo(AppScope::class)
 interface DescriptionComponent {
   fun fatherProvider(): FatherProvider
   fun motherProvider(): MotherProvider
+  fun petMap(): Map<Class<out God>, @JvmSuppressWildcards Pet>
 }

--- a/sample/library/src/main/java/com/squareup/anvil/sample/pet/Pet.kt
+++ b/sample/library/src/main/java/com/squareup/anvil/sample/pet/Pet.kt
@@ -1,0 +1,30 @@
+package com.squareup.anvil.sample.pet
+
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.anvil.sample.God.HEPHAESTUS
+import com.squareup.anvil.sample.God.HERA
+import com.squareup.anvil.sample.God.ZEUS
+import com.squareup.scopes.AppScope
+import javax.inject.Inject
+
+interface Pet {
+  fun pet(): String
+}
+
+@ContributesMultibinding(AppScope::class)
+@PetKey(ZEUS)
+class ZeusPet @Inject constructor() : Pet {
+  override fun pet(): String = "Doggy"
+}
+
+@ContributesMultibinding(AppScope::class)
+@PetKey(HERA)
+class HeraPet @Inject constructor() : Pet {
+  override fun pet(): String = "Catty"
+}
+
+@ContributesMultibinding(AppScope::class)
+@PetKey(HEPHAESTUS)
+class HEPHAESTUSPet @Inject constructor() : Pet {
+  override fun pet(): String = "Moussy"
+}

--- a/sample/library/src/main/java/com/squareup/anvil/sample/pet/PetKey.kt
+++ b/sample/library/src/main/java/com/squareup/anvil/sample/pet/PetKey.kt
@@ -1,0 +1,7 @@
+package com.squareup.anvil.sample.pet
+
+import com.squareup.anvil.sample.God
+import dagger.MapKey
+
+@MapKey
+annotation class PetKey(val value: God)


### PR DESCRIPTION
This PR's purpose is to show a probable bug, not to merge anything! Try to run `./gradlew :sample:app:assembleDebug` to see

```
> Task :sample:app:kaptDebugKotlin FAILED
anvil/sample/app/build/tmp/kapt3/stubs/debug/com/squareup/anvil/sample/AppComponent.java:9: error: [Dagger/MissingBinding] java.util.Map<java.lang.Class<? extends com.squareup.anvil.sample.God>,com.squareup.anvil.sample.pet.Pet> cannot be provided without an @Provides-annotated method.
public abstract interface AppComponent extends com.squareup.anvil.sample.RandomComponent, com.squareup.anvil.sample.DescriptionComponent {
                ^
      java.util.Map<java.lang.Class<? extends com.squareup.anvil.sample.God>,com.squareup.anvil.sample.pet.Pet> is requested at
          com.squareup.anvil.sample.DescriptionComponent.petMap()
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':sample:app:kaptDebugKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.gradle.internal.KaptWithoutKotlincTask$KaptExecutionWorkAction
   > java.lang.reflect.InvocationTargetException (no error message)
```
